### PR TITLE
basic CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+## SPDX-FileCopyrightText: 2021 Benjamin Brock
+##
+## SPDX-License-Identifier: BSD-3-Clause
+
+cmake_minimum_required(VERSION 3.10)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+project(bcl LANGUAGES CXX)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
+
+enable_testing()
+
+set(bcl_DIR ${CMAKE_CURRENT_LIST_DIR}/cmake)
+find_package(bcl REQUIRED)
+
+add_subdirectory(examples)

--- a/cmake/FindGASNET_EX.cmake
+++ b/cmake/FindGASNET_EX.cmake
@@ -1,0 +1,26 @@
+## SPDX-FileCopyrightText: 2021 Benjamin Brock
+##
+## SPDX-License-Identifier: BSD-3-Clause
+
+if (TARGET GASNET_EX::GASNET_EX OR GASNET_EX_FOUND)
+  return()
+endif()
+
+find_path(GASNET_EX_INCLUDE_DIRS NAMES gasnetex.h)
+
+#find_library(GASNET_EX_LIBRARIES NAMES gasnetex)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GASNET_EX
+  DEFAULT_MSG
+  GASNET_EX_INCLUDE_DIRS
+  #GASNET_EX_LIBRARIES
+)
+
+mark_as_advanced(GASNET_EX_INCLUDE_DIRS GASNET_EX_LIBRARIES)
+
+add_library(GASNET_EX::GASNET_EX UNKNOWN IMPORTED)
+set_target_properties(GASNET_EX::GASNET_EX PROPERTIES
+  #IMPORTED_LOCATION "${GASNET_EX_LIBRARIES}"
+  INTERFACE_INCLUDE_DIRECTORIES "${GASNET_EX_INCLUDE_DIRS}"
+)

--- a/cmake/FindSHMEM.cmake
+++ b/cmake/FindSHMEM.cmake
@@ -1,0 +1,27 @@
+## SPDX-FileCopyrightText: 2021 Benjamin Brock
+##
+## SPDX-License-Identifier: BSD-3-Clause
+
+if (TARGET SHMEM::SHMEM OR SHMEM_FOUND)
+  return()
+endif()
+
+find_path(SHMEM_INCLUDE_DIRS NAMES shmem.h PATHS mpp)
+
+#find_library(SHMEM_LIBRARIES NAMES gasnetex)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(SHMEM
+  DEFAULT_MSG
+  GASNETEX_INCLUDE_DIRS
+  #GASNETEX_LIBRARIES
+)
+
+mark_as_advanced(SHMEM_INCLUDE_DIRS SHMEM_LIBRARIES)
+
+add_library(SHMEM::SHMEM UNKNOWN IMPORTED)
+set_target_properties(SHMEM::SHMEM PROPERTIES
+  #IMPORTED_LOCATION "${SHMEM_LIBRARIES}"
+  INTERFACE_INCLUDE_DIRECTORIES "${SHMEM_INCLUDE_DIRS}/.."
+)
+

--- a/cmake/FindUPCXX.cmake
+++ b/cmake/FindUPCXX.cmake
@@ -1,0 +1,26 @@
+## SPDX-FileCopyrightText: 2021 Benjamin Brock
+##
+## SPDX-License-Identifier: BSD-3-Clause
+
+if (TARGET UPCXX::UPCXX OR UPCXX_FOUND)
+  return()
+endif()
+
+find_path(UPCXX_INCLUDE_DIRS NAMES upcxx.h)
+
+#find_library(UPCXX_LIBRARIES NAMES gasnetex)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(UPCXX
+  DEFAULT_MSG
+  UPCXX_INCLUDE_DIRS
+  #UPCXX_LIBRARIES
+)
+
+mark_as_advanced(UPCXX_INCLUDE_DIRS UPCXX_LIBRARIES)
+
+add_library(UPCXX::UPCXX UNKNOWN IMPORTED)
+set_target_properties(UPCXX::UPCXX PROPERTIES
+  #IMPORTED_LOCATION "${UPCXX_LIBRARIES}"
+  INTERFACE_INCLUDE_DIRECTORIES "${UPCXX_INCLUDE_DIRS}"
+)

--- a/cmake/bclConfig.cmake
+++ b/cmake/bclConfig.cmake
@@ -1,0 +1,47 @@
+## SPDX-FileCopyrightText: 2021 Benjamin Brock
+##
+## SPDX-License-Identifier: BSD-3-Clause
+
+cmake_minimum_required(VERSION 3.10)
+
+# Guard against multiple 'find_package(bcl)' calls
+if (TARGET bcl OR bcl_FOUND)
+  return()
+endif()
+
+set(bcl_LOC ${CMAKE_CURRENT_LIST_DIR}/..)
+list(APPEND CMAKE_MODULE_PATH ${bcl_LOC}/cmake)
+
+## Base target ##
+
+add_library(bcl::core INTERFACE IMPORTED)
+target_include_directories(bcl::core INTERFACE ${bcl_LOC})
+
+## MPI ##
+
+find_package(MPI QUIET)
+if (TARGET MPI::MPI_CXX)
+  add_library(bcl::mpi INTERFACE IMPORTED)
+  target_link_libraries(bcl::mpi INTERFACE bcl::core MPI::MPI_CXX)
+  target_compile_definitions(bcl::mpi INTERFACE BCL_MPI)
+endif()
+
+## SHMEM ##
+
+find_package(SHMEM QUIET MODULE)
+if (TARGET SHMEM::SHMEM)
+  add_library(bcl::shmem INTERFACE IMPORTED)
+  target_link_libraries(bcl::shmem INTERFACE bcl::core SHMEM::SHMEM)
+  target_compile_definitions(bcl::shmem INTERFACE SHMEM)
+endif()
+
+## GASNET_EX ##
+
+find_package(GASNET_EX QUIET MODULE)
+if (TARGET GASNET_EX::GASNET_EX)
+  add_library(bcl::gasnet_ex INTERFACE IMPORTED)
+  target_link_libraries(bcl::gasnet_ex INTERFACE bcl::core GASNET_EX::GASNET_EX)
+  target_compile_definitions(bcl::gasnet_ex INTERFACE GASNET_EX)
+endif()
+
+set(bcl_FOUND ON)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,19 @@
+## SPDX-FileCopyrightText: 2021 Benjamin Brock
+##
+## SPDX-License-Identifier: BSD-3-Clause
+
+find_package(MPI REQUIRED)
+
+function(add_bcl_test TEST_NAME)
+  add_executable(${TEST_NAME} ${ARGN})
+  target_link_libraries(${TEST_NAME} PRIVATE bcl::mpi)
+  add_test(
+  NAME
+    ${TEST_NAME}
+  COMMAND
+    ${MPIEXEC_EXECUTABLE} ${CMAKE_BINARY_DIR}/${TEST_NAME} -n 4
+  )
+endfunction()
+
+add_subdirectory(hashmap)
+add_subdirectory(simple)

--- a/examples/hashmap/CMakeLists.txt
+++ b/examples/hashmap/CMakeLists.txt
@@ -1,0 +1,7 @@
+## SPDX-FileCopyrightText: 2021 Benjamin Brock
+##
+## SPDX-License-Identifier: BSD-3-Clause
+
+add_bcl_test(buffered_inserts buffered_inserts.cpp)
+add_bcl_test(insert_find insert_find.cpp)
+

--- a/examples/simple/CMakeLists.txt
+++ b/examples/simple/CMakeLists.txt
@@ -1,0 +1,6 @@
+## SPDX-FileCopyrightText: 2021 Benjamin Brock
+##
+## SPDX-License-Identifier: BSD-3-Clause
+
+add_bcl_test(hello_world hello_world.cpp)
+add_bcl_test(global_ptr global_ptr.cpp)


### PR DESCRIPTION
This PR implements a basic CMake package config (`cmake/bclConfig.cmake`), which is then used by some of the examples.  The idea is that consuming projects would either put the bcl source dir on `CMAKE_PREFIX_PATH` (recommended), or set `bcl_DIR` to `/path/to/bcl/cmake`, then link the appropriate back end target. Right now, only `bcl::mpi` "works", as the other back ends are incomplete. However, I included them as a starting point should they ever want to be fleshed out: they all rely on a find_package module (`cmake/Find[depdendency].cmake` files) to satisfy the back end lib dependency, then put that constructed target on a `bcl::[backend]` target appropriately.